### PR TITLE
Fix error when `contributes` field is not supplied

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -54,7 +54,7 @@ export const getAvailableThemes = () => {
 
             if (file) {
                 const pkg = JSON5.parse(file)
-                const { themes } = pkg.contributes
+                const { themes } = pkg.contributes || {}
 
                 if (themes) {
                     for (const theme of themes) {


### PR DESCRIPTION
# Problem

It appears that some themes lack the `contributes` field in their `package.json`, which results in the CLI breaking entirely regardless of the command being run.

# Solution

Add handling to ensure the `contributes` field being undefined does not crash the CLI

Resolves #4 