### PR TITLE
Fix MacOS not finding the package.json file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@ import { stat, readFile } from 'fs/promises'
 import JSON5 from 'json5'
 import path from 'path'
 import { convert, getAvailableThemes, getThemeFromName, logArray } from './theme.js'
+import { fileURLToPath } from 'url'
 
-const __dirname = path.dirname(import.meta.url.substring(7))
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const pkg = JSON5.parse(await readFile(path.join(__dirname, '../package.json')))
 
 program

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import JSON5 from 'json5'
 import path from 'path'
 import { convert, getAvailableThemes, getThemeFromName, logArray } from './theme.js'
 
-const __dirname = path.dirname(import.meta.url.substring(8))
+const __dirname = path.dirname(import.meta.url.substring(7))
 const pkg = JSON5.parse(fs.readFileSync(path.join(__dirname, '../package.json')))
 
 program


### PR DESCRIPTION
# Problem

MacOS crashes when running the command because it cannot resolve the path to `package.json`

# Solution

Update the substring to fix the path from being relative to absolute.